### PR TITLE
Feature accessor reader

### DIFF
--- a/python/write_accessor.py
+++ b/python/write_accessor.py
@@ -39,7 +39,6 @@ class CSVWDataFrameAccessor:
         return pd.read_csv(
             buffer,
             sep=self._obj.attrs["dialect"]["delimiter"],
-            decimal=",",
             names=[
                 column["titles"] if "titles" in column else ""
                 for column in self.meta.data["tableSchema"]["columns"]

--- a/python/write_accessor.py
+++ b/python/write_accessor.py
@@ -19,5 +19,5 @@ class CSVWDataFrameAccessor:
         self._obj.to_csv(file_path, **kwargs)
         if len(self._obj.attrs) > 0:
             json_path = file_path + self.METADATA_FILE_SUFFIX
-            with open(json_path, "w") as fobj:
+            with open(json_path, "w", encoding="utf-8") as fobj:
                 json.dump(self._obj.attrs, fobj)

--- a/python/write_accessor.py
+++ b/python/write_accessor.py
@@ -4,19 +4,20 @@ import pandas as pd
 
 ACCESSOR_NAME = "csvw"
 
+
 @pd.api.extensions.register_dataframe_accessor(ACCESSOR_NAME)
 class CSVWDataFrameAccessor:
     """Accessor for pandas data frame with metadata as attrs property."""
 
+    METADATA_FILE_SUFFIX = "-metadata.json"
+
     def __init__(self, pandas_obj):
         self._obj = pandas_obj
-
 
     def write(self, file_path, **kwargs):
         """Write DataFrame to csv file, and metadata to json."""
         self._obj.to_csv(file_path, **kwargs)
         if len(self._obj.attrs) > 0:
-            json_path = file_path.replace(".csv", ".json")
-            with open(json_path, 'w') as fobj:
+            json_path = file_path + self.METADATA_FILE_SUFFIX
+            with open(json_path, "w") as fobj:
                 json.dump(self._obj.attrs, fobj)
-

--- a/python/write_accessor.py
+++ b/python/write_accessor.py
@@ -46,3 +46,11 @@ class CSVWDataFrameAccessor:
             ],
             **kwargs
         )
+
+
+def read_csvw(file_path, **kwargs):
+    df = pd.read_csv(file_path, **kwargs)
+    return CSVWDataFrameAccessor(df).read(file_path, **kwargs)
+
+
+pd.read_csvw = read_csvw


### PR DESCRIPTION
From the FDM-NRW Werkstatt on 19.03.2024

This adds a `read` method to the csvw accessor contributed by Christian.

*CHANGES*:

I made a small modification to the `write` method with regard to the naming of the file. I feel like it is a significant possibility that files in in the same directory as the csv file can share names, e.g. `data.csv` and `data.json`. Therefore I think it's preferable to change the line which named the metadata file with `file_path.replace(".csv", ".json")` to a string append method. The suffix is defined as a class variable, so can be modified with `df.csvw.METADATA_FILE_SUFFIX = "_my_special_metadata"`

*ADDITIONS*:

I added a partially implemented read method:

```
filename = "csvw-workshop/data/german_cities.csv"
df = pd.read_csv(filename)
df.csvw.read(filename)

> | City      | Population [10^6] | Area [km^2] | Postal Code |
> |-----------|-------------------|-------------|-------------|
> | Berlin    | 3.664             | 891.85      | 10115       |
> | Hamburg   | 1.899             | 755.16      | 20095       |
> | Frankfurt | 0.732             | 248.31      | 60306       |
> | Dresden   | 0.549             | 328.31      | 01067       |
> | Aachen    | 0.246             | 160.85      | 52062       |
```

Unfortunatly I can't see a way to store the filename when we call `pd.read`, so with the approach the filename has to be passed in both times. 

We can also register a function to do this, which might be a better way:

```
def read_csvw(file_path, **kwargs):
    df = pd.read_csv(file_path, **kwargs)
    return CSVWDataFrameAccessor(df).read(file_path, **kwargs)


pd.read_csvw = read_csvw
```

Which means that you can run:

```
filename = "csvw-workshop/data/german_cities.csv"
pd.read_csvw(filename)

> | City      | Population [10^6] | Area [km^2] | Postal Code |
> |-----------|-------------------|-------------|-------------|
> | Berlin    | 3.664             | 891.85      | 10115       |
> | Hamburg   | 1.899             | 755.16      | 20095       |
> | Frankfurt | 0.732             | 248.31      | 60306       |
> | Dresden   | 0.549             | 328.31      | 01067       |
> | Aachen    | 0.246             | 160.85      | 52062       |
```

*Future Work*:

1. The StringIO thing is not great, since you're duplicating the data. Someone can probably come up with a better trick for this
2. I only scratched the surface of the metadata file properties - just the seperator and column names. To use the CSVW standard completely, I think you'd need to do something like handling each column individually and constructing a DataFrame from all of the columns to return. 

Happy to discuss any ideas or other topics! 